### PR TITLE
Use __dirname to read in 'pragmaticprogrammer.txt'

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 #! /usr/bin/env node
 var fs = require('fs');
+var path = require('path');
 var args = process.argv.slice(2);
 
-var tips = fs.readFileSync('./pragmaticprogrammer.txt');
+var tips = fs.readFileSync(path.join(__dirname, 'pragmaticprogrammer.txt'));
 var tipList = tips.toString().split('\n');
 
 try {


### PR DESCRIPTION
This should fix #1. Uses the [__dirname](https://nodejs.org/docs/latest/api/globals.html#globals_dirname) of the package to read local data files.

Use `path.join` to combine the two, this gives some free cross-platform support :)
